### PR TITLE
Added the provided props to control style

### DIFF
--- a/docs/pages/styles/index.js
+++ b/docs/pages/styles/index.js
@@ -88,8 +88,9 @@ export default function Styles() {
         color: state.isSelected ? 'red' : 'blue',
         padding: 20,
       }),
-      control: () => ({
-        // none of react-select's styles are passed to <Control />
+      control: (provided, state) => ({
+      // none of react-select's styles are passed to <Control />
+      ...provided,
         width: 200,
       }),
       singleValue: (provided, state) => {


### PR DESCRIPTION
The "provided" prop is not passed to the control style, as a result, it messes the whole style of the select box control style.